### PR TITLE
Add notification support using ntfy.sh

### DIFF
--- a/cmd/tasmotaminder/clientoptions.go
+++ b/cmd/tasmotaminder/clientoptions.go
@@ -17,6 +17,8 @@ const (
 	defaultClientId           = "tasmotaminder"
 	defaultRuleConfigLocation = "/etc/tasmotaminder/rules.yaml"
 	connectionTimeout         = 5 * time.Second
+	defaultNtfyToken          = ""
+	defaultNtfyURL            = ""
 )
 
 func getBrokerUrl() string {
@@ -54,4 +56,11 @@ func getRuleConfig() types.PlugRules {
 	}
 
 	return rules
+}
+
+func getNtfyConfig() (string, string) {
+	token := utils.GetEnvOrDefault("NTFY_TOKEN", defaultNtfyToken)
+	url := utils.GetEnvOrDefault("NTFY_URL", defaultNtfyURL)
+
+	return token, url
 }

--- a/cmd/tasmotaminder/main.go
+++ b/cmd/tasmotaminder/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	s := types.NewState(getRuleConfig())
+	s := types.NewState(getRuleConfig(), notify)
 	defer s.Stop()
 
 	clientOptions := getClientOptions()

--- a/cmd/tasmotaminder/ntfy.go
+++ b/cmd/tasmotaminder/ntfy.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func notify(title string, tags string, body string) error {
+	token, url := getNtfyConfig()
+
+	if url == "" {
+		return nil
+	}
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Title", title)
+	req.Header.Set("Tags", tags)
+
+	response, responseErr := http.DefaultClient.Do(req)
+	if responseErr != nil {
+		return responseErr
+	}
+
+	defer func() {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			log.Println("Error closing response body: %s", closeErr)
+		}
+	}()
+
+	if response.StatusCode >= 400 {
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Printf("Error reading response body: %v", err)
+		} else {
+			log.Printf("Response Status: %d, Response Body: %s", response.StatusCode, string(responseBody))
+		}
+	}
+
+	return nil
+}

--- a/types/plugstate.go
+++ b/types/plugstate.go
@@ -64,7 +64,7 @@ func (ps *PlugState) triggerEvent(client mqtt.Client, s *State) {
 	}
 
 	log.Printf("Evaluating rule:\n%s", rule)
-	go rule.Evaluate(ps, ps.getRuleTarget(client, rule))
+	go rule.Evaluate(s, ps, ps.getRuleTarget(client, rule))
 }
 
 func (ps *PlugState) updateSensor(client mqtt.Client, state *State, sensor *Sensor) {

--- a/types/rules.go
+++ b/types/rules.go
@@ -10,6 +10,8 @@ type PlugRule struct {
 	ResetDurationSeconds int              `yaml:"resetDurationSeconds,omitempty"`
 	PowerTimer           *PowerTimer      `yaml:"powerTimer,omitempty"`
 	PowerSchedules       []*PowerSchedule `yaml:"powerSchedules,omitempty"`
+	Notify               bool             `yaml:"notify,omitempty"`   // Added Notify field
+	Nickname             string           `yaml:"nickname,omitempty"` // Added Nickname field
 }
 
 type PlugRules []*PlugRule
@@ -42,8 +44,16 @@ func (p *PlugRule) String() string {
 	return string(data)
 }
 
-func (p *PlugRule) Evaluate(plug *PlugState, target RuleTarget) {
+func (p *PlugRule) Evaluate(state *State, plug *PlugState, target RuleTarget) {
 	if p.PowerTimer != nil {
-		p.PowerTimer.Evaluate(plug, target)
+		p.PowerTimer.Evaluate(state, plug, p, target)
 	}
+}
+
+// DeviceName returns the Nickname if it's not an empty string, otherwise returns the DeviceId
+func (p *PlugRule) DeviceName() string {
+	if p.Nickname != "" {
+		return p.Nickname
+	}
+	return p.DeviceId
 }


### PR DESCRIPTION
This PR adds support for sending notifications on rule action execution via [ntfy.sh](https://docs.ntfy.sh/).

A ntfy user token and url including topic must be provided via environment variables NTFY_TOKEN and NTFY_URL. 